### PR TITLE
test: cover TAB1-67 audit log and search

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,9 @@
+[mcp_servers.playwright]
+command = "npx"
+args = ["-y", "@playwright/mcp@latest", "--browser", "msedge"]
+startup_timeout_sec = 30
+
+[mcp_servers.chrome-devtools]
+command = "npx"
+args = ["-y", "chrome-devtools-mcp@latest", "--executablePath", "C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe"]
+startup_timeout_sec = 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -26,6 +26,9 @@ jobs:
     env:
       BASE_URL: ${{ vars.BASE_URL }}
       CI: 'true'
+      # Audit Log & Search reseeds a single shared live fixture. It runs in the dedicated
+      # job below so browser-matrix workers cannot overwrite one another's fixture state.
+      CI_EXCLUDE_SHARED_FIXTURE_TESTS: 'true'
     steps:
       - uses: actions/checkout@v6
 
@@ -88,4 +91,54 @@ jobs:
           retention-days: 14
           # A lab intentionally excluded from this project (e.g. Service Workers on Desktop
           # Safari, TAB1-53) never runs Playwright, so no report exists — expected, not an error.
+          if-no-files-found: ignore
+
+  audit-log-search:
+    name: e2e shared fixture (${{ matrix.project }})
+    # Run the mutable audit fixture on its own for this PR and after merge. Other lab-scoped PRs
+    # keep their fast, independent matrix and do not need to rerun it.
+    if: ${{ github.event_name != 'pull_request' || github.head_ref == 'stlc/audit-log-search' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        include:
+          - project: 'Desktop Chrome'
+            browser: chromium
+          - project: 'Desktop Firefox'
+            browser: firefox
+          - project: 'Desktop Edge'
+            browser: chromium
+          - project: 'Desktop Safari'
+            browser: webkit
+    env:
+      BASE_URL: ${{ vars.BASE_URL }}
+      CI: 'true'
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps ${{ matrix.browser }}
+
+      - name: Run Audit Log & Search tests
+        run: npx playwright test --project="${{ matrix.project }}" tests/audit-log-search --workers=1
+
+      - name: Upload report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-audit-log-search-${{ matrix.project }}
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 14
           if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # playwright-typescript
 
 Playwright + TypeScript E2E suite testing [Stagecraft Labs](https://stagecraftlabs.com), a
-practice site with 35 independent "labs" (Forms & Validation, Drag & Drop, etc.), each mapped
+practice site with 36 independent "labs" (Forms & Validation, Drag & Drop, etc.), each mapped
 1:1 to a JIRA story in project `TAB1`. Full depth is in `README.md`; skip there before asking
 "how do I run/configure this" — don't re-derive it here.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # playwright-typescript
 
 Playwright + TypeScript E2E suite testing [Stagecraft Labs](https://stagecraftlabs.com), a
-practice site with 35 independent "labs" (Forms & Validation, Drag & Drop, etc.), each mapped
+practice site with 36 independent "labs" (Forms & Validation, Drag & Drop, etc.), each mapped
 1:1 to a JIRA story in project `TAB1`. Full depth is in `README.md`; skip there before asking
 "how do I run/configure this" — don't re-derive it here.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org)
 [![Node](https://img.shields.io/badge/Node-20%2B-339933?logo=node.js&logoColor=white)](https://nodejs.org)
 
-An end-to-end test framework written in Playwright + TypeScript against [Stagecraft Labs](https://stagecraftlabs.com), a practice site of 35 self-contained "labs" (Forms & Validation, Network & API, Shadow DOM, Service Workers, and so on). Each lab has its own Page Object Model, its own spec file, a test plan, and a requirements traceability matrix.
+An end-to-end test framework written in Playwright + TypeScript against [Stagecraft Labs](https://stagecraftlabs.com), a practice site of 36 self-contained "labs" (Forms & Validation, Network & API, Shadow DOM, Service Workers, and so on). Each lab has its own Page Object Model, its own spec file, a test plan, and a requirements traceability matrix.
 
 **2,658 tests across 35 spec files, running on 4 browser projects.**
 
@@ -439,7 +439,7 @@ The skill runs one complete Software Testing Life Cycle for one lab, end to end,
 
 ### The supporting skills
 
-Beyond the linear path, two cross-cutting skills run at any time: **coverage-analyzer** reports which of the 35 labs have a POM, a spec, both, or neither, with live JIRA status, and recommends what to work on next; **framework-scaffolder** implements identified framework gaps on demand, one per invocation.
+Beyond the linear path, two cross-cutting skills run at any time: **coverage-analyzer** reports which of the 36 labs have a POM, a spec, both, or neither, with live JIRA status, and recommends what to work on next; **framework-scaffolder** implements identified framework gaps on demand, one per invocation.
 
 The pipeline requires the Atlassian MCP, Playwright MCP, and Chrome DevTools MCP servers, plus the Playwright CLI and an authenticated GitHub CLI. It performs a pre-flight check and stops with an explicit list if any is missing — it will not run partially and leave half-written artifacts behind.
 
@@ -451,7 +451,7 @@ The pipeline requires the Atlassian MCP, Playwright MCP, and Chrome DevTools MCP
 
 ## The lab catalog
 
-35 labs, each mapped 1:1 to a JIRA story in project `TAB1` and a URL path under `/practice/`.
+36 labs, each mapped 1:1 to a JIRA story in project `TAB1` and a URL path under `/practice/`.
 
 | JIRA    | Lab                                     | Path                                    |
 | ------- | --------------------------------------- | --------------------------------------- |
@@ -490,6 +490,7 @@ The pipeline requires the Atlassian MCP, Playwright MCP, and Chrome DevTools MCP
 | TAB1-62 | Console & Runtime Diagnostics           | `/practice/console-runtime-diagnostics` |
 | TAB1-63 | Memory & DOM Leak Diagnostics           | `/practice/dom-memory-diagnostics`      |
 | TAB1-64 | Custom Assertions & Matcher Composition | `/practice/custom-assertions`           |
+| TAB1-67 | Audit Log & Search                      | `/practice/audit-log-search`            |
 
 Each lab has a test plan in [docs/test-plan/](docs/test-plan/) and a traceability matrix in [docs/rtm/](docs/rtm/) mapping every AC to the test cases covering it, their last result, and any linked defect.
 

--- a/docs/rtm/audit-log-search.rtm.md
+++ b/docs/rtm/audit-log-search.rtm.md
@@ -1,0 +1,50 @@
+# Requirements Traceability Matrix — Audit Log & Search
+
+| Field      | Value                                                                      |
+| ---------- | -------------------------------------------------------------------------- |
+| JIRA Story | [TAB1-67](https://orhunakkan.atlassian.net/browse/TAB1-67)                 |
+| Lab URL    | https://stagecraftlabs.com/practice/audit-log-search                       |
+| Spec file  | tests/audit-log-search/audit-log-search.spec.ts                            |
+| POM file   | pages/audit-log-search.page.ts                                             |
+| Last run   | 2026-07-24 — 36 / 36 passed (Chrome · Firefox · Edge · Safari) — local run |
+| Generated  | 2026-07-24                                                                 |
+
+---
+
+## Coverage by Acceptance Criterion
+
+| Req     | Acceptance Criterion                                                                                  | Test Case                                                                         | Type | Result |
+| ------- | ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | ---- | ------ |
+| AC-1    | Unauthenticated visitors are told to sign in; non-admin users are told they lack admin access         | negative: unauthenticated and non-admin users receive distinct access messages    | N    | ✅     |
+| AC-2    | Admin reseeding restores the known fixture total, page count, and first-page result count             | positive: admin reseeding restores the known entry and page totals                | P    | ✅     |
+| AC-3    | Next and Prev paginate results; Next is disabled on the final page                                    | positive: Next and Prev change results and the last page disables Next            | P/B  | ✅     |
+| AC-4    | Username search returns the correct seeded count and matching rows                                    | positive: searching bob returns only bob rows with the seeded total               | P    | ✅     |
+| AC-5    | Date-range filtering exposes accessible empty and populated states                                    | positive: date filters expose accessible empty and populated result states        | P/B  | ✅     |
+| AC-6    | SQL-injection-style input is treated as literal search text and a normal search continues to work     | negative: SQL-injection-style input returns no rows and normal search still works | N    | ✅     |
+| AC-7    | A successful login creates an immediately queryable persistent audit event                            | positive: a fresh alice login is immediately queryable after reseeding            | P    | ✅     |
+| AXE     | The audit lab must have no axe-core violations in unauthenticated, populated, and empty-result states | no violations on unauthenticated, populated, and empty-result states              | A11y | ✅     |
+| REQ-NF1 | The audit lab must meet its initial-load performance budget                                           | initial audit-log page load is within budget                                      | Perf | ✅     |
+
+**AC-7 implementation note:** the service deliberately exposes only the fixed `alice` and `bob`
+learning fixtures—there is no registration or user-provisioning contract. The serial suite reseeds
+the shared audit table, signs out/in as `alice`, and asserts that the `alice` query grows beyond
+its known seeded baseline. This validates persistence without inferring a new backend attack surface.
+
+---
+
+## Defects
+
+| ID  | Severity | Summary          | Found by | JIRA | Status |
+| --- | -------- | ---------------- | -------- | ---- | ------ |
+| —   | —        | No defects found | —        | —    | —      |
+
+---
+
+## Traceability Summary
+
+- **ACs covered:** 7 / 7 (AC-1 · AC-2 · AC-3 · AC-4 · AC-5 · AC-6 · AC-7)
+- **Non-functional covered:** 2 / 2 (axe multi-state · performance budget)
+- **Test cases:** 9 × 4 browsers = **36 planned executions**
+- **Fixed-fixture strategy:** ✅ serial, reseed-backed; no account-provisioning endpoint is assumed
+- **Open defects:** 0
+- **Exit criteria:** local all-browser gate passed; awaiting CI confirmation.

--- a/docs/rtm/audit-log-search.rtm.md
+++ b/docs/rtm/audit-log-search.rtm.md
@@ -1,13 +1,13 @@
 # Requirements Traceability Matrix — Audit Log & Search
 
-| Field      | Value                                                                      |
-| ---------- | -------------------------------------------------------------------------- |
-| JIRA Story | [TAB1-67](https://orhunakkan.atlassian.net/browse/TAB1-67)                 |
-| Lab URL    | https://stagecraftlabs.com/practice/audit-log-search                       |
-| Spec file  | tests/audit-log-search/audit-log-search.spec.ts                            |
-| POM file   | pages/audit-log-search.page.ts                                             |
-| Last run   | 2026-07-24 — 36 / 36 passed (Chrome · Firefox · Edge · Safari) — local run |
-| Generated  | 2026-07-24                                                                 |
+| Field      | Value                                                                        |
+| ---------- | ---------------------------------------------------------------------------- |
+| JIRA Story | [TAB1-67](https://orhunakkan.atlassian.net/browse/TAB1-67)                   |
+| Lab URL    | https://stagecraftlabs.com/practice/audit-log-search                         |
+| Spec file  | tests/audit-log-search/audit-log-search.spec.ts                              |
+| POM file   | pages/audit-log-search.page.ts                                               |
+| Last run   | 2026-07-24 — 36 / 36 passed (Chrome · Firefox · Edge · Safari) — CI verified |
+| Generated  | 2026-07-24                                                                   |
 
 ---
 
@@ -47,4 +47,4 @@ its known seeded baseline. This validates persistence without inferring a new ba
 - **Test cases:** 9 × 4 browsers = **36 planned executions**
 - **Fixed-fixture strategy:** ✅ serial, reseed-backed; no account-provisioning endpoint is assumed
 - **Open defects:** 0
-- **Exit criteria:** local all-browser gate passed; awaiting CI confirmation.
+- **Exit criteria:** ✅ all-browser local and CI gates passed.

--- a/docs/test-plan/audit-log-search.test-plan.md
+++ b/docs/test-plan/audit-log-search.test-plan.md
@@ -1,0 +1,65 @@
+# Test Plan — Audit Log & Search (TAB1-67)
+
+## 1. Scope
+
+In scope: admin authorization messages; reseeding and seeded counts; pagination; username and date-range filters; SQL-injection-style literal search handling; and durable login-event persistence for the fixed fixture identities.
+
+Out of scope: Azure SQL implementation details, database load testing, and any backend APIs not exposed by the Audit Log & Search UI.
+
+## 2. Test types
+
+Functional tests cover positive, negative, boundary, and data-driven cases. Accessibility scans cover initial, authorization-error, empty-result, populated-result, and post-reseed states. A tagged performance test covers initial page load. All cases run cross-browser.
+
+## 3. Environments & data
+
+The live target is supplied by `BASE_URL` in `.env` (with optional `.env.<ENV>` override). Tests use the documented fixed `alice` admin and `bob` non-admin accounts, plus fixed date/search values for deterministic filtering. The application intentionally exposes no account-provisioning endpoint; `test.describe.configure({ mode: 'serial' })` protects the shared mutable audit fixture while each specification reseeds its known baseline.
+
+## 4. Browser / device matrix
+
+| Project         |
+| --------------- |
+| Desktop Chrome  |
+| Desktop Firefox |
+| Desktop Edge    |
+| Desktop Safari  |
+
+## 5. Risk assessment & priority
+
+| Area / Requirement                               | Likelihood | Impact | Risk | Priority |
+| ------------------------------------------------ | ---------- | ------ | ---- | -------- |
+| Admin authorization and access messaging         | M          | H      | H    | P1       |
+| Reseed action and seeded count/page total        | M          | H      | H    | P1       |
+| Pagination and final-page boundary               | M          | H      | H    | P1       |
+| Username filtering and returned-row correctness  | M          | H      | H    | P1       |
+| Date-range empty and populated states            | M          | H      | H    | P1       |
+| SQL-injection-style search is treated literally  | M          | H      | H    | P1       |
+| Fixed-user login event is persistently queryable | M          | H      | H    | P1       |
+| Invalid/blank filters and disabled controls      | M          | M      | M    | P2       |
+| Accessibility in all rendered states             | M          | H      | H    | P1       |
+| Initial-load performance budget                  | M          | M      | M    | P2       |
+
+## 6. Entry criteria
+
+- TAB1-67 requirements are extracted and prioritized.
+- The Audit Log & Search URL is reachable with `BASE_URL` configured.
+- The POM, fixture, and required test data are available.
+
+## 7. Exit criteria
+
+- All P1 and P2 requirements have passing automated coverage.
+- No open non-flaky High-or-higher defect is linked to TAB1-67.
+- No critical or serious axe violations remain, or each is tracked and accepted.
+- CI is green for all four desktop-browser projects.
+- The RTM is current.
+
+## 8. Deliverables
+
+- `pages/audit-log-search.page.ts`
+- `tests/audit-log-search/audit-log-search.spec.ts`
+- `docs/rtm/audit-log-search.rtm.md`
+- This test plan
+- Lab-scoped GitHub Actions run and open PR
+
+## 9. Schedule / effort
+
+Requirements → test plan → locator audit/POM → fixture → spec → local execution/triage → RTM → PR → CI verification → JIRA closure.

--- a/fixtures/index.ts
+++ b/fixtures/index.ts
@@ -35,6 +35,7 @@ import { ClientStoragePartitioningPage } from '../pages/client-storage-partition
 import { ConsoleRuntimeDiagnosticsPage } from '../pages/console-runtime-diagnostics.page';
 import { CustomAssertionsPage } from '../pages/custom-assertions.page';
 import { DomMemoryDiagnosticsPage } from '../pages/dom-memory-diagnostics.page';
+import { AuditLogSearchPage } from '../pages/audit-log-search.page';
 
 type Fixtures = {
   fakeAuthPage: FakeAuthPage;
@@ -73,6 +74,7 @@ type Fixtures = {
   consoleRuntimeDiagnosticsPage: ConsoleRuntimeDiagnosticsPage;
   customAssertionsPage: CustomAssertionsPage;
   domMemoryDiagnosticsPage: DomMemoryDiagnosticsPage;
+  auditLogSearchPage: AuditLogSearchPage;
 };
 
 export const test = base.extend<Fixtures>({
@@ -183,6 +185,9 @@ export const test = base.extend<Fixtures>({
   },
   domMemoryDiagnosticsPage: async ({ page }, use) => {
     await use(new DomMemoryDiagnosticsPage(page));
+  },
+  auditLogSearchPage: async ({ page }, use) => {
+    await use(new AuditLogSearchPage(page));
   },
 });
 

--- a/pages/audit-log-search.page.ts
+++ b/pages/audit-log-search.page.ts
@@ -1,0 +1,41 @@
+import { Locator, Page } from '@playwright/test';
+
+export class AuditLogSearchPage {
+  // ── Filters ───────────────────────────────────────────────────────────
+  readonly usernameInput: Locator;
+  readonly fromDateInput: Locator;
+  readonly toDateInput: Locator;
+  readonly searchButton: Locator;
+
+  // ── Results ───────────────────────────────────────────────────────────
+  readonly auditLogEntries: Locator;
+  readonly auditLogItems: Locator;
+  readonly emptyResultsMessage: Locator;
+  readonly pageSummary: Locator;
+  readonly previousPageButton: Locator;
+  readonly nextPageButton: Locator;
+
+  // ── Actions & feedback ────────────────────────────────────────────────
+  readonly reseedButton: Locator;
+  readonly alertMessage: Locator;
+
+  constructor(page: Page) {
+    // ── Filters ─────────────────────────────────────────────────────────
+    this.usernameInput = page.getByRole('textbox', { name: 'Username contains' });
+    this.fromDateInput = page.getByRole('textbox', { name: 'From date' });
+    this.toDateInput = page.getByRole('textbox', { name: 'To date' });
+    this.searchButton = page.getByRole('button', { name: 'Search' });
+
+    // ── Results ─────────────────────────────────────────────────────────
+    this.auditLogEntries = page.getByRole('list', { name: 'Audit log entries' });
+    this.auditLogItems = this.auditLogEntries.getByRole('listitem');
+    this.emptyResultsMessage = page.getByText('No audit log entries match this search.');
+    this.pageSummary = page.getByText(/Page \d+ of \d+ \(\d+ total\)/);
+    this.previousPageButton = page.getByRole('button', { name: 'Prev' });
+    this.nextPageButton = page.getByRole('button', { name: 'Next' });
+
+    // ── Actions & feedback ──────────────────────────────────────────────
+    this.reseedButton = page.getByRole('button', { name: 'Reseed fixture data' });
+    this.alertMessage = page.getByRole('alert');
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,8 +4,11 @@ import * as dotenv from 'dotenv';
 dotenv.config({ path: `.env.${process.env.ENV}`, override: true });
 dotenv.config({ path: '.env' });
 
+const sharedFixtureTestIgnore = process.env.CI_EXCLUDE_SHARED_FIXTURE_TESTS === 'true' ? ['**/audit-log-search/**'] : [];
+
 export default defineConfig({
   testDir: './tests',
+  testIgnore: sharedFixtureTestIgnore,
   snapshotDir: './fixtures/reference-snapshots',
   snapshotPathTemplate: '{snapshotDir}/{testFileName}/{arg}{ext}',
   fullyParallel: true,
@@ -40,7 +43,7 @@ export default defineConfig({
       // responding once context.setOffline(true) is set — confirmed with a raw fetch() call, no
       // app/test code involved. Not fixable in this app's source. Explicit team scope decision:
       // this lab is not run on Safari; all other labs keep full 4-browser coverage.
-      testIgnore: '**/service-workers/**',
+      testIgnore: ['**/service-workers/**', ...sharedFixtureTestIgnore],
     },
   ],
 });

--- a/skills/README.md
+++ b/skills/README.md
@@ -29,9 +29,9 @@ early ("⛔ guardrail") rather than guessing when it lacks a required input or t
 
 ## The domain: Stagecraft Labs + JIRA
 
-The whole flow is built around a fixed catalog of **35 practice "labs"** (Forms & Validation,
+The whole flow is built around a fixed catalog of **36 practice "labs"** (Forms & Validation,
 Async UI, Network & API, etc.), each mapped 1:1 to a **JIRA story** in project `TAB1`
-(keys `TAB1-12` … `TAB1-41`, `TAB1-60` … `TAB1-64`) and a **URL path** under `/practice/...`. This mapping table is
+(keys `TAB1-12` … `TAB1-41`, `TAB1-60` … `TAB1-64`, `TAB1-67`) and a **URL path** under `/practice/...`. This mapping table is
 embedded in every skill that needs it, so any skill can resolve a lab name → JIRA key → URL →
 file paths without external lookups.
 
@@ -116,7 +116,7 @@ and **stops** if any are missing rather than producing a partial artifact.
      PR stays open — merge is a manual, human step
 
   Cross-cutting (run any time, not in the linear path):
-   • coverage-analyzer    — which of the 35 labs have POM/spec/tests; what to do next
+   • coverage-analyzer    — which of the 36 labs have POM/spec/tests; what to do next
    • framework-scaffolder — implement one of 10 framework gaps (fixtures, auth, mocking…)
 ```
 
@@ -146,7 +146,7 @@ and **stops** if any are missing rather than producing a partial artifact.
 
 | Skill                    | File                                               | What it does                                                                                                                                                                                                                         |
 | ------------------------ | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **coverage-analyzer**    | [coverage-analyzer.md](coverage-analyzer.md)       | Reports which of the 35 labs have a POM, a spec, both, or neither — with live JIRA status — and recommends the next lab to work on.                                                                                                  |
+| **coverage-analyzer**    | [coverage-analyzer.md](coverage-analyzer.md)       | Reports which of the 36 labs have a POM, a spec, both, or neither — with live JIRA status — and recommends the next lab to work on.                                                                                                  |
 | **framework-scaffolder** | [framework-scaffolder.md](framework-scaffolder.md) | Implements one of 10 identified framework gaps on demand (auth `storageState`, `page.route` mocking, custom fixtures, global setup, typed env, Allure, seeding, flake/quarantine, worker isolation, mobile). One gap per invocation. |
 
 ---

--- a/skills/coverage-analyzer.md
+++ b/skills/coverage-analyzer.md
@@ -75,6 +75,7 @@ This table is embedded in the skill. Do not derive it from the POM — use it di
 | TAB1-62  | Console & Runtime Diagnostics           | /practice/console-runtime-diagnostics | 3 — Specialized |
 | TAB1-63  | Memory & DOM Leak Diagnostics           | /practice/dom-memory-diagnostics      | 3 — Specialized |
 | TAB1-64  | Custom Assertions & Matcher Composition | /practice/custom-assertions           | 3 — Specialized |
+| TAB1-67  | Audit Log & Search                      | /practice/audit-log-search            | 3 — Specialized |
 
 ---
 
@@ -146,9 +147,9 @@ Project: playwright-typescript  |  Analyzed: <date>
 
 ---
 Summary:
-  ✅ Fully covered:  X / 35 labs
-  ⚠️ Partial:        X / 35 labs
-  ❌ Not started:    X / 35 labs
+  ✅ Fully covered:  X / 36 labs
+  ⚠️ Partial:        X / 36 labs
+  ❌ Not started:    X / 36 labs
 
 Top 3 recommended next labs (Priority Group 1 first, then ❌ before ⚠️):
   1. TAB1-13 Forms & Validation — ❌ missing POM + spec

--- a/skills/jira-sync.md
+++ b/skills/jira-sync.md
@@ -18,7 +18,7 @@ compatibility: >
 
 # Playwright JIRA Sync
 
-Keeps JIRA story status aligned with actual test development progress across all 35 labs.
+Keeps JIRA story status aligned with actual test development progress across all 36 labs.
 
 ---
 
@@ -72,6 +72,7 @@ Keeps JIRA story status aligned with actual test development progress across all
 | TAB1-62  | Console & Runtime Diagnostics           | /practice/console-runtime-diagnostics |
 | TAB1-63  | Memory & DOM Leak Diagnostics           | /practice/dom-memory-diagnostics      |
 | TAB1-64  | Custom Assertions & Matcher Composition | /practice/custom-assertions           |
+| TAB1-67  | Audit Log & Search                      | /practice/audit-log-search            |
 
 ---
 

--- a/skills/requirement-extractor.md
+++ b/skills/requirement-extractor.md
@@ -63,6 +63,7 @@ This table is the authoritative mapping of Stagecraft labs to JIRA story keys:
 | TAB1-62  | Console & Runtime Diagnostics           | /practice/console-runtime-diagnostics |
 | TAB1-63  | Memory & DOM Leak Diagnostics           | /practice/dom-memory-diagnostics      |
 | TAB1-64  | Custom Assertions & Matcher Composition | /practice/custom-assertions           |
+| TAB1-67  | Audit Log & Search                      | /practice/audit-log-search            |
 
 ---
 

--- a/skills/stlc-pipeline.md
+++ b/skills/stlc-pipeline.md
@@ -74,6 +74,7 @@ PR — that stays a manual, human action.
 | TAB1-62  | Console & Runtime Diagnostics           | /practice/console-runtime-diagnostics |
 | TAB1-63  | Memory & DOM Leak Diagnostics           | /practice/dom-memory-diagnostics      |
 | TAB1-64  | Custom Assertions & Matcher Composition | /practice/custom-assertions           |
+| TAB1-67  | Audit Log & Search                      | /practice/audit-log-search            |
 
 ---
 

--- a/skills/test-case-generator.md
+++ b/skills/test-case-generator.md
@@ -61,6 +61,7 @@ stays 1:1 traceable to code while the coverage reflects real test design, not ha
 | TAB1-62  | Console & Runtime Diagnostics           | /practice/console-runtime-diagnostics | —                         |
 | TAB1-63  | Memory & DOM Leak Diagnostics           | /practice/dom-memory-diagnostics      | —                         |
 | TAB1-64  | Custom Assertions & Matcher Composition | /practice/custom-assertions           | Gap #3 (fixtures)         |
+| TAB1-67  | Audit Log & Search                      | /practice/audit-log-search            | Gap #7 (seeding)          |
 
 ---
 

--- a/skills/test-triage.md
+++ b/skills/test-triage.md
@@ -66,6 +66,7 @@ when a lab passes locally but fails in CI.
 | console-runtime-diagnostics | TAB1-62  |
 | dom-memory-diagnostics      | TAB1-63  |
 | custom-assertions           | TAB1-64  |
+| audit-log-search            | TAB1-67  |
 
 ---
 

--- a/tests/audit-log-search/audit-log-search.spec.ts
+++ b/tests/audit-log-search/audit-log-search.spec.ts
@@ -1,0 +1,181 @@
+import { test, expect } from '../../fixtures/index';
+import { scanWcag } from '../../utilities/accessibility';
+import type { Page } from '@playwright/test';
+
+// JIRA: https://orhunakkan.atlassian.net/browse/TAB1-67 — Audit Log & Search
+
+const AUDIT_LOG_URL = '/practice/audit-log-search';
+const LOGIN_URL = '/practice/fake-auth';
+const ADMIN = { username: 'alice', password: 'password123' };
+const USER = { username: 'bob', password: 'letmein' };
+const SEEDED_TOTAL = 120;
+const SEEDED_PAGE_COUNT = 6;
+const SEEDED_USERNAME_TOTAL = 24;
+const SQL_INJECTION_SEARCH = "' OR '1'='1' --";
+
+async function signIn(page: Page, credentials: { username: string; password: string }) {
+  await page.goto(LOGIN_URL);
+  await page.getByRole('textbox', { name: 'Username' }).fill(credentials.username);
+  await page.getByRole('textbox', { name: 'Password' }).fill(credentials.password);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(page).toHaveURL(/\/practice\/fake-auth\/dashboard$/);
+}
+
+async function seedAuditLog(page: Page) {
+  await signIn(page, ADMIN);
+  await page.goto(AUDIT_LOG_URL);
+  await page.getByRole('button', { name: 'Reseed fixture data' }).click();
+  await expect(page.getByText(`Page 1 of ${SEEDED_PAGE_COUNT} (${SEEDED_TOTAL} total)`)).toBeVisible();
+}
+
+test.describe('Audit Log & Search', () => {
+  // Reseeding intentionally mutates one shared Azure SQL audit table. Fixed alice/bob identities
+  // are the supported fixture contract; do not add account-provisioning endpoints for this lab.
+  test.describe.configure({ mode: 'serial' });
+
+  // AC-1 (TAB1-67): Tests assert an unauthenticated session sees a "must be signed in as an admin"
+  // message, and a non-admin session (bob) sees a "does not have admin access" message.
+  test.describe('AC-1 — admin authorization', () => {
+    test('negative: unauthenticated and non-admin users receive distinct access messages', async ({ page, auditLogSearchPage }) => {
+      await page.goto(AUDIT_LOG_URL);
+      await expect(auditLogSearchPage.alertMessage).toContainText('must be signed in as an admin');
+
+      await signIn(page, USER);
+      await page.goto(AUDIT_LOG_URL);
+      await expect(auditLogSearchPage.alertMessage).toContainText('does not have admin access');
+      await expect(auditLogSearchPage.auditLogEntries).toHaveCount(0);
+    });
+  });
+
+  // AC-2 (TAB1-67): Tests reseed fixture data via the reseed action and assert the admin sees
+  // seeded audit log entries with the correct total count and page count.
+  test.describe('AC-2 — fixture reseeding', () => {
+    test('positive: admin reseeding restores the known entry and page totals', async ({ page, auditLogSearchPage }) => {
+      await seedAuditLog(page);
+      await expect(auditLogSearchPage.pageSummary).toHaveText(`Page 1 of ${SEEDED_PAGE_COUNT} (${SEEDED_TOTAL} total)`);
+      await expect(auditLogSearchPage.auditLogItems).toHaveCount(20);
+      await expect(auditLogSearchPage.alertMessage).toHaveCount(0);
+    });
+  });
+
+  // AC-3 (TAB1-67): Tests paginate with Next and Prev and assert the row content changes between
+  // pages, including at the last-page boundary.
+  test.describe('AC-3 — server-side pagination', () => {
+    test('positive: Next and Prev change results and the last page disables Next', async ({ page, auditLogSearchPage }) => {
+      await seedAuditLog(page);
+      const firstPageRows = await auditLogSearchPage.auditLogItems.allTextContents();
+
+      await auditLogSearchPage.nextPageButton.click();
+      await expect(auditLogSearchPage.pageSummary).toHaveText(`Page 2 of ${SEEDED_PAGE_COUNT} (${SEEDED_TOTAL} total)`);
+      await expect(auditLogSearchPage.auditLogItems).not.toHaveText(firstPageRows);
+
+      await auditLogSearchPage.previousPageButton.click();
+      await expect(auditLogSearchPage.pageSummary).toHaveText(`Page 1 of ${SEEDED_PAGE_COUNT} (${SEEDED_TOTAL} total)`);
+      await expect(auditLogSearchPage.auditLogItems).toHaveText(firstPageRows);
+
+      for (let pageNumber = 1; pageNumber < SEEDED_PAGE_COUNT; pageNumber += 1) {
+        await auditLogSearchPage.nextPageButton.click();
+      }
+      await expect(auditLogSearchPage.pageSummary).toHaveText(`Page ${SEEDED_PAGE_COUNT} of ${SEEDED_PAGE_COUNT} (${SEEDED_TOTAL} total)`);
+      await expect(auditLogSearchPage.nextPageButton).toBeDisabled();
+      await expect(auditLogSearchPage.previousPageButton).toBeEnabled();
+    });
+  });
+
+  // AC-4 (TAB1-67): Tests filter by username search and assert the filtered result count and that
+  // returned rows contain the searched username.
+  test.describe('AC-4 — username search', () => {
+    test('positive: searching bob returns only bob rows with the seeded total', async ({ page, auditLogSearchPage }) => {
+      await seedAuditLog(page);
+      await auditLogSearchPage.usernameInput.fill(USER.username);
+      await auditLogSearchPage.searchButton.click();
+
+      await expect(auditLogSearchPage.pageSummary).toHaveText(`Page 1 of 2 (${SEEDED_USERNAME_TOTAL} total)`);
+      await expect(auditLogSearchPage.auditLogItems).toHaveCount(20);
+      const rows = await auditLogSearchPage.auditLogItems.allTextContents();
+      rows.forEach((row) => expect(row).toContain(USER.username));
+    });
+  });
+
+  // AC-5 (TAB1-67): Tests filter by a date range and assert both the "no results" empty state and
+  // a populated results state, using accessible roles rather than counting DOM nodes directly.
+  test.describe('AC-5 — date-range filtering', () => {
+    test('positive: date filters expose accessible empty and populated result states', async ({ page, auditLogSearchPage }) => {
+      await seedAuditLog(page);
+      await auditLogSearchPage.fromDateInput.fill('2099-01-01');
+      await auditLogSearchPage.toDateInput.fill('2099-12-31');
+      await auditLogSearchPage.searchButton.click();
+      await expect(auditLogSearchPage.emptyResultsMessage).toBeVisible();
+      await expect(auditLogSearchPage.auditLogEntries).toHaveCount(0);
+
+      await auditLogSearchPage.fromDateInput.fill('2026-04-01');
+      await auditLogSearchPage.toDateInput.fill('2026-05-01');
+      await auditLogSearchPage.searchButton.click();
+      await expect(auditLogSearchPage.auditLogEntries).toBeVisible();
+      await expect(auditLogSearchPage.auditLogItems).toHaveCount(20);
+    });
+  });
+
+  // AC-6 (TAB1-67): Tests submit a SQL-injection-style search string and assert it is treated as
+  // a safe literal substring with no matching rows, then run a normal search afterward.
+  test.describe('AC-6 — injection-safe literal search', () => {
+    test('negative: SQL-injection-style input returns no rows and normal search still works', async ({ page, auditLogSearchPage }) => {
+      await seedAuditLog(page);
+      await auditLogSearchPage.usernameInput.fill(SQL_INJECTION_SEARCH);
+      await auditLogSearchPage.searchButton.click();
+      await expect(auditLogSearchPage.emptyResultsMessage).toBeVisible();
+      await expect(auditLogSearchPage.pageSummary).toHaveText('Page 1 of 1 (0 total)');
+
+      await auditLogSearchPage.usernameInput.fill(ADMIN.username);
+      await auditLogSearchPage.searchButton.click();
+      await expect(auditLogSearchPage.pageSummary).toHaveText(`Page 1 of 2 (${SEEDED_USERNAME_TOTAL} total)`);
+      await expect(auditLogSearchPage.auditLogEntries).toBeVisible();
+    });
+  });
+
+  // AC-7 (TAB1-67, adapted): fixed fixture identities are intentional. A fresh alice login must
+  // be immediately queryable after reseeding, proving the shared persistent audit trail is updated.
+  test.describe('AC-7 — fixed-identity login-event persistence', () => {
+    test('positive: a fresh alice login is immediately queryable after reseeding', async ({ page, auditLogSearchPage }) => {
+      await seedAuditLog(page);
+      await page.goto('/practice/fake-auth/dashboard');
+      await page.getByRole('button', { name: 'Sign out' }).click();
+      await expect(page).toHaveURL(/\/practice\/fake-auth$/);
+      await signIn(page, ADMIN);
+      await page.goto(AUDIT_LOG_URL);
+      await auditLogSearchPage.usernameInput.fill(ADMIN.username);
+      await auditLogSearchPage.searchButton.click();
+
+      await expect(auditLogSearchPage.pageSummary).toHaveText(/Page 1 of \d+ \((?:2[5-9]|[3-9]\d+|\d{3,}) total\)/);
+      await expect(auditLogSearchPage.auditLogItems.first()).toContainText(ADMIN.username);
+    });
+  });
+
+  test.describe('accessibility (WCAG 2.x, axe)', () => {
+    test('no violations on unauthenticated, populated, and empty-result states', async ({ page, auditLogSearchPage }) => {
+      await page.goto(AUDIT_LOG_URL);
+      expect((await scanWcag(page)).violations).toEqual([]);
+
+      await seedAuditLog(page);
+      expect((await scanWcag(page)).violations).toEqual([]);
+
+      await auditLogSearchPage.fromDateInput.fill('2099-01-01');
+      await auditLogSearchPage.toDateInput.fill('2099-12-31');
+      await auditLogSearchPage.searchButton.click();
+      await expect(auditLogSearchPage.emptyResultsMessage).toBeVisible();
+      expect((await scanWcag(page)).violations).toEqual([]);
+    });
+  });
+});
+
+test.describe('performance @performance', () => {
+  test('initial audit-log page load is within budget', async ({ page }) => {
+    await page.goto(AUDIT_LOG_URL);
+    const timing = await page.evaluate(() => {
+      const navigation = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming;
+      return { domContentLoaded: navigation.domContentLoadedEventEnd, load: navigation.loadEventEnd };
+    });
+    expect(timing.domContentLoaded).toBeLessThan(6000);
+    expect(timing.load).toBeLessThan(12000);
+  });
+});

--- a/tests/audit-log-search/audit-log-search.spec.ts
+++ b/tests/audit-log-search/audit-log-search.spec.ts
@@ -63,6 +63,7 @@ test.describe('Audit Log & Search', () => {
   test.describe('AC-3 — server-side pagination', () => {
     test('positive: Next and Prev change results and the last page disables Next', async ({ page, auditLogSearchPage }) => {
       await seedAuditLog(page);
+      await expect(auditLogSearchPage.auditLogItems).toHaveCount(20);
       const firstPageRows = await auditLogSearchPage.auditLogItems.allTextContents();
 
       await auditLogSearchPage.nextPageButton.click();


### PR DESCRIPTION
## Summary\n- add the Audit Log & Search POM and fixture\n- cover TAB1-67 AC-1 through AC-7, multi-state axe, and performance\n- document the serial fixed-fixture AC-7 strategy: alice/bob are intentional fixtures and no account-provisioning API is inferred\n\n## Verification\n- 
px eslint tests/audit-log-search/audit-log-search.spec.ts pages/audit-log-search.page.ts fixtures/index.ts\n- 
px playwright test tests/audit-log-search/audit-log-search.spec.ts --workers=1 --reporter=list (36 passed: Chrome, Firefox, Edge, Safari)\n- 
px tsc --noEmit remains blocked by pre-existing nullability errors in other lab specs; no TAB1-67 type errors.\n\nCloses TAB1-67.